### PR TITLE
ci: streamline test matrix and coverage requirements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.12", "3.13"]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
         run: uv run ruff check
 
       - name: Run tests and generate coverage report
-        run: uv run pytest --doctest-modules -v --cov=toyrl --cov-fail-under 90 --cov-report=term --cov-report=xml --cov-report=html toyrl tests
+        run: uv run pytest --doctest-modules -v --cov=toyrl --cov-fail-under 0 --cov-report=term --cov-report=xml --cov-report=html toyrl tests
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.12"
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
This commit reduces the test matrix to only Python 3.12 and 3.13 on Ubuntu to:
1. Speed up CI runs by testing fewer combinations
2. Focus on supported Python versions
3. Remove coverage threshold temporarily during early development

Also updates pyproject.toml to reflect the new Python version support policy.