### PR TITLE
fix(pyproject): correct license format and remove redundant classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "toyrl"
 version = "0.2.0"
 description = "A clean reinforcement learning library"
 authors = [{ name = "Xiangzhuang Shen", email = "datahonor@gmail.com" }]
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 readme = "README.md"
 
 
@@ -11,7 +11,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
This commit:
1. Changes the license format from object to string to match PEP 621 standards
2. Removes the redundant 'License' classifier since it's already specified in the license field

The changes make the configuration cleaner and more standards-compliant while maintaining the same licensing information.